### PR TITLE
Fix PID Autotune for Heated Bed

### DIFF
--- a/Marlin/src/gcode/temperature/M303.cpp
+++ b/Marlin/src/gcode/temperature/M303.cpp
@@ -37,7 +37,7 @@
  */
 void GcodeSuite::M303() {
 
-  const int8_t e = parser.byteval('E');
+  const int8_t e = parser.intval('E');
 
   if (!WITHIN(e, 0
     #if ENABLED(PIDTEMPBED)


### PR DESCRIPTION
fixes a regression in M303.cpp
e could never be negative so E-1 for PID Autotune the heated bed results in Autotune of the Extuder

### Related Issues

fixes #12468
